### PR TITLE
Fix with_items: barword_variable issue

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,14 +6,14 @@
 
 - name: Install rubies
   sudo: true
-  with_items: ruby_install_ruby_versions
+  with_items: "{{ruby_install_ruby_versions}}"
   shell: >
     creates=/opt/rubies/ruby-{{ item }}/bin/ruby
     ruby-install ruby {{ item }}
 
 - name: Install bundler for rubies
   sudo: true
-  with_items: ruby_install_ruby_versions
+  with_items: "{{ruby_install_ruby_versions}}"
   shell: >
     creates=/opt/rubies/ruby-{{ item }}/bin/bundle
     executable=/bin/bash source /etc/profile;
@@ -23,10 +23,10 @@
   sudo: yes
   sudo_user: "{{ item }}"
   template: src=gemrc dest=~/.gemrc
-  with_items: ruby_users
+  with_items: "{{ruby_users}}"
 
 - name: Copy .ruby-version
   sudo: yes
   sudo_user: "{{ item }}"
   template: src=ruby-version dest=~/.ruby-version
-  with_items: ruby_users
+  with_items: "{{ruby_users}}"


### PR DESCRIPTION
This fixes the problem with ansible 2.2.0.0 where the previously deprecated feature (using with_items and barword variable) now causes an error.